### PR TITLE
Fix switch to nonroot user in service-catalog's Dockerfile

### DIFF
--- a/service-catalog/Dockerfile
+++ b/service-catalog/Dockerfile
@@ -15,6 +15,6 @@ COPY --from=build /app/app /app
 
 EXPOSE 8080
 
-USER nonroot:nonroot
+USER nobody:nobody
 
 ENTRYPOINT ["/app"]


### PR DESCRIPTION
Tested in:
* Windows 11 + WSL2 + Ubuntu 24.04 + Docker Desktop
* MacOS X 15.5 + Docker Desktop (Intel & Apple Silicon)

Building the service-catalog image fails when ran locally, due to its Dockerfile referencing a "nonroot" user account that does not exist in the base image. The PR fixes this by using the "nobody" account instead.

```
$ docker compose -f docker-compose.yaml up --build
[...]
dummy_service-1    | time=2025-08-04T05:23:14.233Z level=ERROR msg="gRPC request handled" service=products source=grpc grpc_service=grpc.ProductService grpc_method=updateProductStock grpc_code=InvalidArgument duration_ms=16
Error response from daemon: unable to find user nonroot: no matching entries in passwd file
```